### PR TITLE
Updated the streamlit version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,4 @@ pdfplumber==0.9.0
 fpdf==1.7.2
 
 # Deployment & UI
-streamlit==1.33.0
+streamlit==1.37.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ fpdf==1.7.2
 
 # Deployment & UI
 streamlit==1.37.0
+numpy==1.26.4 


### PR DESCRIPTION
Updated the streamlit version from streamlit==1.33.0 to streamlit==1.37.0 to overcome the issue of Over Capacity on streamlit.
Added the numpy version 1.26.4 due to compatibility issue of streamlit==1.37.0.